### PR TITLE
Predicate primitives

### DIFF
--- a/laure.c
+++ b/laure.c
@@ -38,7 +38,7 @@ struct cmd_info {
 };
 
 const struct cmd_info commands[] = {
-    {0, ".consult", -1, "Consults files. Any number of args, each arg is a filename."},
+    {0, ".consult", -1, "Consults files. Each arg is a filename."},
     {1, ".quit", 0, "Quits laurelang REPL."},
     {2, ".help", 0, "Shows this message."},
     {3, ".flags", 0, "Shows all available flags for laure interpreter."},

--- a/lib/array/array.le
+++ b/lib/array/array.le
@@ -3,6 +3,7 @@
 : ?each_int(int[]) -> int.
 ?each_int(arr) -> element when each(arr) = element.
 
+// Predicate states that there are no nearby standing equal elements in array
 : ?no_repeat(int[]).
 
 ?no_repeat([]).

--- a/lib/test/test.c
+++ b/lib/test/test.c
@@ -178,10 +178,10 @@ qresp test_predicate_run(preddata *pd, control_ctx *cctx) {
     for (int i = 0; i < len; i++) {
         Instance *predicate = tests[i];
         struct PredicateImage *pred_im = (struct PredicateImage*)predicate->image;
-        char spaces[28] = {0};
+        char spaces[128] = {0};
         for (int j = laure_string_strlen(predicate->name); j < max_name_len; j++) {
             strcat(spaces, " ");
-            if (j >= 27) break;
+            if (j >= 127) break;
         }
 
         if (should_skip(skips, predicate->name)) {

--- a/src/apply.c
+++ b/src/apply.c
@@ -99,6 +99,63 @@ string get_nested_ins_name(Instance *atom, uint nesting, laure_stack_t *stack) {
     return strdup(buff);
 }
 
+void *laure_apply_pred(laure_expression_t *predicate_exp, laure_stack_t *stack) {
+    struct InstanceSet *args_set = instance_set_new();
+    uint all_count = laure_expression_get_count(predicate_exp->ba->set);
+    if (predicate_exp->ba->has_resp) all_count--;
+
+    uint idx = 0;
+    uint *nestings = malloc(sizeof(void*) * (all_count - predicate_exp->ba->body_len));
+
+    for (int i = predicate_exp->ba->body_len; i < all_count; i++) {
+        laure_expression_t *aexp = laure_expression_set_get_by_idx(predicate_exp->ba->set, i);
+        uint nesting = aexp->flag;
+        string tname;
+        if (nesting) {
+            Instance *to_nest = laure_stack_get(stack, aexp->s);
+            if (!to_nest) {
+                return NULL;
+            }
+            tname = get_nested_ins_name(to_nest, nesting, stack);
+        } else {
+            tname = aexp->s;
+        }
+        Instance *arg = laure_stack_get(stack, tname);
+        if (! arg) {
+            return NULL;
+        }
+        instance_set_push(args_set, arg);
+        nestings[idx] = nesting;
+        idx++;
+    }
+
+    Instance *resp;
+    uint resp_nesting = 0;
+    if (predicate_exp->ba->has_resp) {
+        laure_expression_t *rexp = laure_expression_set_get_by_idx(predicate_exp->ba->set, idx);
+        string tname;
+        resp_nesting = rexp->flag;
+        if (resp_nesting) {
+            Instance *to_nest = laure_stack_get(stack, rexp->s);
+            if (!to_nest) {
+                return NULL;
+            }
+            tname = get_nested_ins_name(to_nest, resp_nesting, stack);
+        } else tname = rexp->s;
+        resp = laure_stack_get(stack, tname);
+        if (! resp) {
+            return NULL;
+        }
+    } else {
+        resp = NULL;
+    }
+
+    struct PredicateImage *img = predicate_header_new(args_set, resp, predicate_exp->t == let_constraint);
+    img->header.nestings = nestings;
+    img->header.response_nesting = resp_nesting;
+    return img;
+}
+
 apply_result_t laure_consult_predicate(laure_session_t *session, laure_stack_t *stack, laure_expression_t *predicate_exp, string address) {
     assert(predicate_exp->t == let_pred || predicate_exp->t == let_constraint);
     Instance *pred_ins = laure_stack_get(stack, predicate_exp->s);
@@ -160,59 +217,9 @@ apply_result_t laure_consult_predicate(laure_session_t *session, laure_stack_t *
 
         Instance *maybe_header = pred_ins;
 
-        struct InstanceSet *args_set = instance_set_new();
-        uint all_count = laure_expression_get_count(predicate_exp->ba->set);
-        if (predicate_exp->ba->has_resp) all_count--;
+        void *img = laure_apply_pred(predicate_exp, stack);
 
-        uint idx = 0;
-        uint *nestings = malloc(sizeof(void*) * (all_count - predicate_exp->ba->body_len));
-
-        for (int i = predicate_exp->ba->body_len; i < all_count; i++) {
-            laure_expression_t *aexp = laure_expression_set_get_by_idx(predicate_exp->ba->set, i);
-            uint nesting = aexp->flag;
-            string tname;
-            if (nesting) {
-                Instance *to_nest = laure_stack_get(stack, aexp->s);
-                if (!to_nest) {
-                    return respond_apply(apply_error, "error reaching instance to nest");
-                }
-                tname = get_nested_ins_name(to_nest, nesting, stack);
-            } else {
-                tname = aexp->s;
-            }
-            Instance *arg = laure_stack_get(stack, tname);
-            if (! arg) {
-                return respond_apply(apply_error, "predicate argument hint is undefined in scope");
-            }
-            instance_set_push(args_set, arg);
-            nestings[idx] = nesting;
-            idx++;
-        }
-
-        Instance *resp;
-        uint resp_nesting = 0;
-        if (predicate_exp->ba->has_resp) {
-            laure_expression_t *rexp = laure_expression_set_get_by_idx(predicate_exp->ba->set, idx);
-            string tname;
-            resp_nesting = rexp->flag;
-            if (resp_nesting) {
-                Instance *to_nest = laure_stack_get(stack, rexp->s);
-                if (!to_nest) {
-                    return respond_apply(apply_error, "error reaching instance to nest");
-                }
-                tname = get_nested_ins_name(to_nest, resp_nesting, stack);
-            } else tname = rexp->s;
-            resp = laure_stack_get(stack, tname);
-            if (! resp) {
-                return respond_apply(apply_error, "predicate response hint is undefined in scope");
-            }
-        } else {
-            resp = NULL;
-        }
-
-        struct PredicateImage *img = predicate_header_new(args_set, resp, predicate_exp->t == let_constraint);
-        img->header.nestings = nestings;
-        img->header.response_nesting = resp_nesting;
+        if (! img) return respond_apply(apply_error, "predicate hint is undefined");
 
         string name = strdup(predicate_exp->s);
         Instance *ins = instance_new(name, session->_doc_buffer, img);

--- a/src/apply.c
+++ b/src/apply.c
@@ -20,17 +20,18 @@ apply_result_t respond_apply(apply_status_t status, string e) {
 bool laure_load_shared(laure_session_t *session, char *path) {
     void *lib = dlopen(path, RTLD_NOW);
 
-    uint *dfn = dlsym(lib, "DFLAG_N");
-    *dfn = DFLAG_N;
-
-   void *dfs = dlsym(lib, "DFLAGS");
-   memcpy(dfs, DFLAGS, DFLAG_MAX * 32 * 2);
-   
     // Shared CLE (C logic environment) extension
     if (!lib) {
         printf("failed to load shared CLE extension %s\n\\ %s\n", path, dlerror());
         return false;
     }
+
+    uint *dfn = dlsym(lib, "DFLAG_N");
+    *dfn = DFLAG_N;
+
+    void *dfs = dlsym(lib, "DFLAGS");
+    memcpy(dfs, DFLAGS, DFLAG_MAX * 32 * 2);
+    
     int (*perform_upload)(laure_session_t*) = dlsym(lib, "package_include");
     if (!perform_upload) {
         printf("function cle_perform_upload(laure_session_t*) is undefined in CLE extension %s\n", path);

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -90,6 +90,7 @@ void laure_register_builtins(laure_session_t *session) {
         img->t = !builtin.is_constraint ? PREDICATE_FACT : CONSTRAINT_FACT;
         img->variations = variations;
         img->translator = NULL;
+        img->is_primitive = false;
 
         Instance *ins = instance_new(builtin.name, builtin.doc, img);
         ins->repr = builtin.is_constraint ? bc_repr : bp_repr;
@@ -212,6 +213,7 @@ Instance *laure_cle_add_predicate(
     img->t = !is_constraint ? PREDICATE_FACT : CONSTRAINT_FACT;
     img->variations = variations;
     img->translator = NULL;
+    img->is_primitive = false;
 
     Instance *ins = instance_new(name, doc, img);
     ins->repr = is_constraint ? bc_repr : bp_repr;

--- a/src/instance.c
+++ b/src/instance.c
@@ -98,6 +98,7 @@ struct PredicateImage *predicate_header_new(struct InstanceSet *args, Instance *
     img->translator = NULL;
     img->header = header;
     img->variations = pvs_new();
+    img->is_primitive = false;
     
     return img;
 }
@@ -694,8 +695,11 @@ string predicate_repr(Instance *ins) {
         snprintf(respbuff, 64, " -> %s", img->header.resp->name);
     } else
         respbuff[0] = 0;
+
+    string name = ins->name;
+    if (img->is_primitive) name = "\0";
     
-    snprintf(buff, 128, "(?%s(%s)%s)", ins->name, argsbuff, respbuff);
+    snprintf(buff, 128, "(?%s(%s)%s)", name, argsbuff, respbuff);
     return strdup(buff);
 }
 
@@ -1404,6 +1408,24 @@ bool img_equals(void* img1, void* img2) {
             EnhancedImageHead head2 = read_enhanced_head(img2);
             if (strcmp(head.identifier, head2.identifier) != 0) return false;
             return head.eq && head.eq(img1, img2);
+        }
+        case PREDICATE_FACT:
+        case CONSTRAINT_FACT: {
+            struct PredicateImage *p1 = (struct PredicateImage*)img1;
+            struct PredicateImage *p2 = (struct PredicateImage*)img2;
+            if (! (p1->is_primitive || p2->is_primitive)) return false;
+            else if (p1->is_primitive && p2->is_primitive) {
+                printf("cmp primitives not implemented\n");
+                return false;
+            }
+            struct PredicateImage *prim, *nonprim;
+            if (p1->is_primitive) {
+                prim = p1; nonprim = p2;
+            } else {
+                prim = p2; nonprim = p1;
+            }
+            
+            // ...
         }
     }
 }

--- a/src/instance.c
+++ b/src/instance.c
@@ -494,7 +494,7 @@ bool predicate_search_check(Instance *chd, struct PredicateImage *prim) {
 
     if (
         (prim->header.args->len != nonprim->header.args->len) ||
-        (prim->header.resp != nonprim->header.resp) || 
+        ((prim->header.resp == 0) != (nonprim->header.resp == 0)) || 
         (prim->header.response_nesting != nonprim->header.response_nesting)
     ) return false;
 
@@ -650,14 +650,12 @@ gen_resp image_generate(laure_stack_t *stack, void* img, gen_resp (*rec)(void*, 
                     if (predicate_search_check(cell.instance, im)) {
                         gen_resp resp = rec(cell.instance->image, external_ctx);
                         found = true;
-                        if (!resp.r) return resp;
                     }
                 }, false);
                 STACK_ITER(stack->global, cell, {
                     if (predicate_search_check(cell.instance, im)) {
                         gen_resp resp = rec(cell.instance->image, external_ctx);
                         found = true;
-                        if (!resp.r) return resp;
                     }
                 }, false);
                 if (! found) {
@@ -683,6 +681,7 @@ gen_resp image_generate(laure_stack_t *stack, void* img, gen_resp (*rec)(void*, 
     }
     gen_resp gr;
     gr.r = true;
+    gr.qr = respond(q_true, 0);
     return gr;
 };
 
@@ -1009,6 +1008,7 @@ bool instantiated(Instance *ins) {
             return ((struct ArrayImage*)ins->image)->state == I;
         case ATOM:
             return ((struct AtomImage*)ins->image)->unified;
+        case CONSTRAINT_FACT:
         case PREDICATE_FACT:
             return true;
         case STRUCTURE:
@@ -1503,7 +1503,7 @@ bool img_equals(void* img1, void* img2) {
             
             if (
                 (prim->header.args->len != nonprim->header.args->len) ||
-                (prim->header.resp != nonprim->header.resp) || 
+                ((prim->header.resp == 0) != (nonprim->header.resp == 0)) || 
                 (prim->header.response_nesting != nonprim->header.response_nesting)
             ) return false;
 

--- a/src/laureimage.h
+++ b/src/laureimage.h
@@ -241,6 +241,7 @@ struct PredicateHeaderImage {
 
 struct PredicateImage {
     IMAGE_HEAD
+    bool is_primitive;
     struct PredicateHeaderImage header;
     struct PredicateImageVariationSet *variations;
 };

--- a/src/laurelang.h
+++ b/src/laurelang.h
@@ -286,6 +286,7 @@ qresp laure_eval(control_ctx *cctx, laure_expression_set *expression_set);
 control_ctx *laure_control_ctx_get(laure_session_t *session, laure_expression_set *expset);
 
 void laure_register_builtins(laure_session_t*);
+void *laure_apply_pred(laure_expression_t *predicate_exp, laure_stack_t *stack);
 
 void laure_consult_recursive(laure_session_t *session, char *path);
 

--- a/src/laurelang.h
+++ b/src/laurelang.h
@@ -356,6 +356,7 @@ struct laure_flag {
 extern uint DFLAG_N;
 extern char DFLAGS[DFLAG_MAX][2][32];
 extern char* EXPT_NAMES[];
+extern char* IMG_NAMES[];
 
 char *get_dflag(char *flagname);
 void add_dflag(char *flagname, char *value);

--- a/src/parser.c
+++ b/src/parser.c
@@ -22,7 +22,7 @@ string RESTRICTED = "[](). ";
 #define LAURE_SYNTAX_INFIX_PREPOSITION "of"
 #endif
 
-char* EXPT_NAMES[] = {"Expression Set", "Variable", "Predicate Call", "Declaration", "Assertion", "Imaging", "Predicate Declaration", "Choice (Packed)", "Choice (Unpacked)", "Naming", "Value", "Constraint", "Structure Definition", "Structure", "Array", "Unify", "Quantified Expression", "Domain", "Implication", "Reference", "Cut", "[Nope]"};
+char* EXPT_NAMES[] = {"Expression Set", "Variable", "Predicate Call", "Declaration", "Assertion", "Imaging", "Predicate Declaration", "Choice (Packed)", "Choice (Unpacked)", "Naming", "Value", "Constraint", "Structure Definition", "Structure", "Array", "Unify", "Quantified Expression", "Domain", "Implication", "Reference", "Cut", "Predicate Primitive", "[Nope]"};
 
 laure_expression_t *laure_expression_create(laure_expression_type t, string docstring, bool is_header, string s, uint flag, laure_expression_compact_bodyargs *ba) {
     laure_expression_t *exp = malloc(sizeof(laure_expression_t));
@@ -640,10 +640,11 @@ laure_parse_result laure_parse(string query) {
             }
 
             laure_expression_compact_bodyargs *ba = laure_bodyargs_create(set, body_len, has_resp);
+            bool is_primitive = strlen(name) == 0 && body_len == 0;
 
             laure_parse_result lpr;
             lpr.is_ok = true;
-            lpr.exp = laure_expression_create(type, "", false, name, 0, ba);
+            lpr.exp = laure_expression_create(type, "", false, name, is_primitive, ba);
 
             return lpr;
         }

--- a/src/parser.c
+++ b/src/parser.c
@@ -565,7 +565,8 @@ laure_parse_result laure_parse(string query) {
                 query = query + strlen(args) + 1;
 
                 string sp = read_til(query, '>');
-                resp = query + strlen(sp) + 2;
+                if (sp)
+                    resp = query + strlen(sp) + 2;
                 
                 free(sp);
             } else if (easy_pattern_parse(query, ".*(.*).*")) {

--- a/src/query.c
+++ b/src/query.c
@@ -1049,8 +1049,11 @@ qresp laure_eval(control_ctx *cctx, laure_expression_set *expression_set) {
             struct PredicateImage *pred_img = (struct PredicateImage*) predicate_ins->image;
 
             if (pred_img->is_primitive) {
+                /*
                 predicate_addvar(pred_img, ent_exp);
                 return RESPOND_OK;
+                */
+                RESPOND_ERROR("primitive (%s) call is prohibited before instantiation; unify", predicate_name);
             }
             
             if (is_constraint) {

--- a/src/query.c
+++ b/src/query.c
@@ -632,7 +632,6 @@ qresp laure_eval(control_ctx *cctx, laure_expression_set *expression_set) {
 
     switch(ent_exp->t) {
         case let_assert: {
-
             laure_expression_t *lvar = laure_expression_set_get_by_idx(ent_exp->ba->set, 0);
             laure_expression_t *rvar = laure_expression_set_get_by_idx(ent_exp->ba->set, 1);
             
@@ -1604,6 +1603,7 @@ qresp laure_eval(control_ctx *cctx, laure_expression_set *expression_set) {
             break;
         }
         case let_set: {
+            if (! ent_exp->ba->set) return RESPOND_OK;
             qcontext *nqctx = qcontext_new(ent_exp->ba->set);
             nqctx->next = qcontext_new_shifted(qctx, expression_set);
             laure_stack_t *private_stack = laure_stack_clone(stack, true);

--- a/src/stack.c
+++ b/src/stack.c
@@ -260,7 +260,7 @@ void laure_stack_show(laure_stack_t* stack) {
         Instance *instance = stack->current.cells[i].instance;
         long link = stack->current.cells[i].link_id;
         string r = instance != NULL ? instance->repr(instance) : NULL;
-        printf("%d: name=%s link=%ld value=%s doc=%s\n", i, instance == NULL ? "?" : instance->name, link, r == NULL ? "(deleted)" : r, instance == NULL ? "" : (instance->doc == NULL ? "-" : "+"));
+        printf("%ld: %sname=%s%s %svalue=%s%s\n", link, GRAY_COLOR, NO_COLOR, instance == NULL ? "?" : instance->name, GRAY_COLOR, NO_COLOR, r == NULL ? "(deleted)" : r);
         free(r);
     }
     printf("---\n");

--- a/tests/logic.le
+++ b/tests/logic.le
@@ -134,3 +134,21 @@
 ?test_empty_set() {
     {{{{{{}}}}}};
 }
+
+// 14
+// 40
+: ?test_pred_prim(natural).
+?test_pred_prim(x) {
+    prim ~ (?(int, int) -> int);
+    prim = +|-|*;
+    x = 4 prim 10;
+}
+
+: ?test_pred_prim_fullsearch().
+?test_pred_prim_fullsearch() {
+    primitive ~ (?(int) -> int);
+    primitive?;
+    primitive(-100) = 100;
+    primitive(8 - 10) = x;
+    &all x { x = 2 };
+}


### PR DESCRIPTION
Predicate primitives are unnamed relation declarations. Concepts and syntax are same for contraint primitives.

Assigning predicate requires arity and argument universums correspondence:

```
pred ~ (?(int) -> int);
pred = prime | fac;
// assigning to predicate with different arity should fail.
(pred = +) -> fail();
```

Unifying predicate primitive will lead to global predicate search.

```
pred ~ (?(int, int) -> int);
pred?;
```

Type in predicate primitive may be anonymous.

```
prim ~ (?(int, _) -> _);
```

Predicate primitives are never equal, same as predicates.

Calling a predicate primitive will lead to case creation. All cases will be compared if predicate primitive gets instantiated to some particular predicate.

When creating a declaration with predicate primitive type, prim. type must be enclosed in parentheses.

When declaring a primitive with response argument, prim. type must be enclosed in parentheses not to confuse it with implication.

# Ideas

Calling primitive never creates a choicepoint and never fails. Calls are postponed to be evaluated on instatiation.

```
prim ~ (?(int, int) -> int);
prim(1, 2) = 3;
prim(3, 8) = 11;
&all prim { prim = + }
```